### PR TITLE
[HOTFIX] Allow hiding the create password screen

### DIFF
--- a/login-workflow/LICENSES.json
+++ b/login-workflow/LICENSES.json
@@ -1,5 +1,5 @@
 {
-    "@brightlayer-ui/react-auth-shared@3.7.0": {
+    "@brightlayer-ui/react-auth-shared@4.0.0-alpha.0": {
         "licenses": "BSD-3-Clause",
         "repository": "https://github.com/etn-ccis/blui-react-auth-shared/tree/master",
         "licenseUrl": "https://github.com/etn-ccis/blui-react-auth-shared/tree/master",

--- a/login-workflow/package.json
+++ b/login-workflow/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@brightlayer-ui/react-native-auth-workflow",
     "description": "Re-usable workflow components for Authentication and Registration within Eaton applications.",
-    "version": "5.1.0",
+    "version": "6.0.0-alpha.0",
     "license": "BSD-3-Clause",
     "author": {
         "name": "Brightlayer UI",
@@ -57,7 +57,7 @@
         "tag:package": "npx -p @brightlayer-ui/tag blui-tag -s -blui-react-native-auth-workflow"
     },
     "dependencies": {
-        "@brightlayer-ui/react-auth-shared": "^3.7.3",
+        "@brightlayer-ui/react-auth-shared": "^4.0.0-alpha.0",
         "lodash.clonedeep": "^4.5.0",
         "react-native-status-bar-height": "^2.5.0"
     },

--- a/login-workflow/src/screens/InviteRegistrationPager.tsx
+++ b/login-workflow/src/screens/InviteRegistrationPager.tsx
@@ -349,7 +349,12 @@ export const InviteRegistrationPager: React.FC<InviteRegistrationPagerProps> = (
                 canGoForward: true,
                 canGoBack: false,
             },
-        ]);
+        ])
+        // Remove the CreatePassword screen if so configured
+        .filter((page) => {
+            if (page.name === 'CreatePassword' && !(injectedUIContext.enableCreatePassword ?? true)) return false;
+            return true;
+        });
     const isLastStep = currentPage === RegistrationPages.length - 1;
     const isFirstStep = currentPage === 0;
     const CompletePage = RegistrationPages.length - 1;

--- a/login-workflow/src/screens/Login.tsx
+++ b/login-workflow/src/screens/Login.tsx
@@ -383,141 +383,148 @@ export const Login: React.FC<LoginProps> = (props) => {
                 contentContainerStyle={[{ flexGrow: 1, backgroundColor: theme.colors.surface }]}
                 keyboardShouldPersistTaps={'always'}
             >
-                {loginHeader || <LoginHeaderSplash style={containerStyles.topArea} mainImage={projectImage} />}
-                {debugButton}
-                {debugMessage}
-                {debugLinks}
-                {(loginErrorDisplayConfig.mode === 'message-box' || loginErrorDisplayConfig.mode === 'both') &&
-                    loginErrorDisplayConfig.position !== 'bottom' &&
-                    errorMessageBox}
-                <SafeAreaView
-                    style={[
-                        containerStyles.mainContainer,
-                        {
-                            flexGrow: 1,
-                            width: 'auto',
-                            flexDirection: 'row',
-                            justifyContent: 'center',
-                        },
-                    ]}
-                >
-                    <View style={[{ flexGrow: 1, maxWidth: 600 }]}>
-                        <TextInput
-                            testID={'email-text-field'}
-                            accessibilityLabel={'email-text-field'}
-                            label={loginType === 'email' ? t('blui:LABELS.EMAIL') : t('blui:LABELS.USERNAME')}
-                            value={emailInput}
-                            keyboardType={loginType === 'email' ? 'email-address' : 'default'}
-                            style={{ marginTop: 48 }}
-                            onChangeText={(text: string): void => {
-                                setEmailInput(text);
-                                setHasEmailFormatError(false);
-                                setHasUsernameFormatError(false);
-                                if (authUIState.login.transitErrorMessage !== null)
-                                    authUIActions.dispatch(AccountActions.resetLogin());
-                            }}
-                            onSubmitEditing={(): void => {
-                                goToNextInput();
-                            }}
-                            blurOnSubmit={false}
-                            returnKeyType={'next'}
-                            error={isInvalidCredentials || hasEmailFormatError || hasUsernameFormatError}
-                            errorText={
-                                isInvalidCredentials
-                                    ? t('blui:LOGIN.INCORRECT_CREDENTIALS')
-                                    : hasEmailFormatError
-                                    ? t('blui:MESSAGES.EMAIL_ENTRY_ERROR')
-                                    : hasUsernameFormatError
-                                    ? t('blui:MESSAGES.USERNAME_ENTRY_ERROR')
-                                    : ''
-                            }
-                            onBlur={(): void => {
-                                if (loginType === 'email' && emailInput.length > 0 && !EMAIL_REGEX.test(emailInput)) {
-                                    setHasEmailFormatError(true);
-                                } else if (
-                                    loginType === 'username' &&
-                                    emailInput.length > 0 &&
-                                    !USERNAME_REGEX.test(emailInput)
-                                )
-                                    setHasUsernameFormatError(true);
-                            }}
-                        />
-                        <TextInputSecure
-                            testID={'password-text-field'}
-                            accessibilityLabel={'password-text-field'}
-                            ref={confirmPasswordRef}
-                            label={t('blui:LABELS.PASSWORD')}
-                            value={passwordInput}
-                            autoCapitalize={'none'}
-                            onChangeText={(text: string): void => {
-                                setPasswordInput(text);
-                                if (authUIState.login.transitErrorMessage !== null)
-                                    authUIActions.dispatch(AccountActions.resetLogin());
-                            }}
-                            returnKeyType={'done'}
-                            style={{ marginTop: 44 }}
-                            error={isInvalidCredentials}
-                            errorText={t('blui:LOGIN.INCORRECT_CREDENTIALS')}
-                            onSubmitEditing={
-                                !EMAIL_REGEX.test(emailInput) || !USERNAME_REGEX.test(emailInput) || !passwordInput
-                                    ? undefined
-                                    : loginTapped
-                            }
-                        />
+                <>
+                    {loginHeader || <LoginHeaderSplash style={containerStyles.topArea} mainImage={projectImage} />}
+                    {debugButton}
+                    {debugMessage}
+                    {debugLinks}
+                    {(loginErrorDisplayConfig.mode === 'message-box' || loginErrorDisplayConfig.mode === 'both') &&
+                        loginErrorDisplayConfig.position !== 'bottom' &&
+                        errorMessageBox}
+                    <SafeAreaView
+                        style={[
+                            containerStyles.mainContainer,
+                            {
+                                flexGrow: 1,
+                                width: 'auto',
+                                flexDirection: 'row',
+                                justifyContent: 'center',
+                            },
+                        ]}
+                    >
+                        <View style={[{ flexGrow: 1, maxWidth: 600 }]}>
+                            <TextInput
+                                testID={'email-text-field'}
+                                accessibilityLabel={'email-text-field'}
+                                label={loginType === 'email' ? t('blui:LABELS.EMAIL') : t('blui:LABELS.USERNAME')}
+                                value={emailInput}
+                                keyboardType={loginType === 'email' ? 'email-address' : 'default'}
+                                style={{ marginTop: 48 }}
+                                onChangeText={(text: string): void => {
+                                    setEmailInput(text);
+                                    setHasEmailFormatError(false);
+                                    setHasUsernameFormatError(false);
+                                    if (authUIState.login.transitErrorMessage !== null)
+                                        authUIActions.dispatch(AccountActions.resetLogin());
+                                }}
+                                onSubmitEditing={(): void => {
+                                    goToNextInput();
+                                }}
+                                blurOnSubmit={false}
+                                returnKeyType={'next'}
+                                error={isInvalidCredentials || hasEmailFormatError || hasUsernameFormatError}
+                                errorText={
+                                    isInvalidCredentials
+                                        ? t('blui:LOGIN.INCORRECT_CREDENTIALS')
+                                        : hasEmailFormatError
+                                        ? t('blui:MESSAGES.EMAIL_ENTRY_ERROR')
+                                        : hasUsernameFormatError
+                                        ? t('blui:MESSAGES.USERNAME_ENTRY_ERROR')
+                                        : ''
+                                }
+                                onBlur={(): void => {
+                                    if (
+                                        loginType === 'email' &&
+                                        emailInput.length > 0 &&
+                                        !EMAIL_REGEX.test(emailInput)
+                                    ) {
+                                        setHasEmailFormatError(true);
+                                    } else if (
+                                        loginType === 'username' &&
+                                        emailInput.length > 0 &&
+                                        !USERNAME_REGEX.test(emailInput)
+                                    )
+                                        setHasUsernameFormatError(true);
+                                }}
+                            />
+                            <TextInputSecure
+                                testID={'password-text-field'}
+                                accessibilityLabel={'password-text-field'}
+                                ref={confirmPasswordRef}
+                                label={t('blui:LABELS.PASSWORD')}
+                                value={passwordInput}
+                                autoCapitalize={'none'}
+                                onChangeText={(text: string): void => {
+                                    setPasswordInput(text);
+                                    if (authUIState.login.transitErrorMessage !== null)
+                                        authUIActions.dispatch(AccountActions.resetLogin());
+                                }}
+                                returnKeyType={'done'}
+                                style={{ marginTop: 44 }}
+                                error={isInvalidCredentials}
+                                errorText={t('blui:LOGIN.INCORRECT_CREDENTIALS')}
+                                onSubmitEditing={
+                                    !EMAIL_REGEX.test(emailInput) || !USERNAME_REGEX.test(emailInput) || !passwordInput
+                                        ? undefined
+                                        : loginTapped
+                                }
+                            />
 
-                        {(loginErrorDisplayConfig.mode === 'message-box' || loginErrorDisplayConfig.mode === 'both') &&
-                            loginErrorDisplayConfig.position === 'bottom' &&
-                            errorMessageBox}
+                            {(loginErrorDisplayConfig.mode === 'message-box' ||
+                                loginErrorDisplayConfig.mode === 'both') &&
+                                loginErrorDisplayConfig.position === 'bottom' &&
+                                errorMessageBox}
 
-                        <View style={[containerStyles.loginControls]}>
-                            <View style={[containerStyles.checkboxAndButton]}>
-                                {showRememberMe && (
-                                    <Checkbox
-                                        label={t('blui:ACTIONS.REMEMBER')}
-                                        checked={rememberPassword}
-                                        style={[containerStyles.checkbox]}
-                                        onPress={(): void => setRememberPassword(!rememberPassword)}
-                                    />
-                                )}
-                                <View style={[containerStyles.loginButtonContainer]}>
-                                    <ToggleButton
-                                        text={t('blui:ACTIONS.LOG_IN')}
-                                        disabled={
-                                            loginType === 'email'
-                                                ? !EMAIL_REGEX.test(emailInput) || !passwordInput
-                                                : loginType === 'username'
-                                                ? !USERNAME_REGEX.test(emailInput) || !passwordInput
-                                                : !emailInput || !passwordInput
-                                        }
-                                        onPress={loginTapped}
-                                        testID={'login-button'}
-                                        accessibilityLabel={'login-button'}
-                                    />
+                            <View style={[containerStyles.loginControls]}>
+                                <View style={[containerStyles.checkboxAndButton]}>
+                                    {showRememberMe && (
+                                        <Checkbox
+                                            label={t('blui:ACTIONS.REMEMBER')}
+                                            checked={rememberPassword}
+                                            style={[containerStyles.checkbox]}
+                                            onPress={(): void => setRememberPassword(!rememberPassword)}
+                                        />
+                                    )}
+                                    <View style={[containerStyles.loginButtonContainer]}>
+                                        <ToggleButton
+                                            text={t('blui:ACTIONS.LOG_IN')}
+                                            disabled={
+                                                loginType === 'email'
+                                                    ? !EMAIL_REGEX.test(emailInput) || !passwordInput
+                                                    : loginType === 'username'
+                                                    ? !USERNAME_REGEX.test(emailInput) || !passwordInput
+                                                    : !emailInput || !passwordInput
+                                            }
+                                            onPress={loginTapped}
+                                            testID={'login-button'}
+                                            accessibilityLabel={'login-button'}
+                                        />
+                                    </View>
                                 </View>
                             </View>
-                        </View>
-                        {loginActions && typeof loginActions === 'function' && loginActions(navigation)}
-                        {loginActions && typeof loginActions !== 'function' && loginActions}
-                        <View>
-                            {enableResetPassword && (
-                                <Button
-                                    mode={'text'}
-                                    labelStyle={styles.clearButton}
-                                    uppercase={false}
-                                    onPress={(): void => navigation.navigate('PasswordResetInitiation')}
-                                >
-                                    <Body1 color="primary">{t('blui:LABELS.FORGOT_PASSWORD')}</Body1>
-                                </Button>
-                            )}
+                            {loginActions && typeof loginActions === 'function' && loginActions(navigation)}
+                            {loginActions && typeof loginActions !== 'function' && loginActions}
+                            <View>
+                                {enableResetPassword && (
+                                    <Button
+                                        mode={'text'}
+                                        labelStyle={styles.clearButton}
+                                        uppercase={false}
+                                        onPress={(): void => navigation.navigate('PasswordResetInitiation')}
+                                    >
+                                        <Body1 color="primary">{t('blui:LABELS.FORGOT_PASSWORD')}</Body1>
+                                    </Button>
+                                )}
 
-                            {createAccountOption}
-                            {contactEatonRepresentative}
-                            {loginFooter && typeof loginFooter === 'function' && loginFooter(navigation)}
-                            {loginFooter && typeof loginFooter !== 'function' && loginFooter}
+                                {createAccountOption}
+                                {contactEatonRepresentative}
+                                {loginFooter && typeof loginFooter === 'function' && loginFooter(navigation)}
+                                {loginFooter && typeof loginFooter !== 'function' && loginFooter}
+                            </View>
+                            {showCybersecurityBadge && <CybersecurityBadge containerStyle={styles.securityBadge} />}
                         </View>
-                        {showCybersecurityBadge && <CybersecurityBadge containerStyle={styles.securityBadge} />}
-                    </View>
-                </SafeAreaView>
+                    </SafeAreaView>
+                </>
             </ScrollViewWithBackground>
         </>
     );

--- a/login-workflow/src/screens/SelfRegistrationPager.tsx
+++ b/login-workflow/src/screens/SelfRegistrationPager.tsx
@@ -417,13 +417,19 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
                 canGoForward: true,
                 canGoBack: false,
             },
-        ]);
+        ])
+        // Remove the CreatePassword screen if so configured
+        .filter((page) => {
+            if (page.name === 'CreatePassword' && !(injectedUIContext.enableCreatePassword ?? true)) return false;
+            return true;
+        });
     const isLastStep = currentPage === RegistrationPages.length - 1;
     const isFirstStep = currentPage === 0;
     const CompletePage = RegistrationPages.length - 1;
     const CreateAccountPage = RegistrationPages.findIndex((item) => item.name === 'CreateAccount');
     const VerifyEmailPage = RegistrationPages.findIndex((item) => item.name === 'VerifyEmail');
     const CreatePasswordPage = RegistrationPages.findIndex((item) => item.name === 'CreatePassword');
+    const AccountDetailsPage = RegistrationPages.findIndex((item) => item.name === 'AccountDetails');
 
     // If there is a code and it is not confirmed, go to the verify screen
     useEffect((): void => {
@@ -461,9 +467,10 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
         }
     }, [setHasAcknowledgedError, registrationActions, verificationCode, email, setAccountAlreadyExists]);
 
+    // If the email is validated successfully, go to the create password screen (or account details)
     useEffect(() => {
         if (currentPage === VerifyEmailPage && validationSuccess) {
-            setCurrentPage(CreatePasswordPage);
+            setCurrentPage(injectedUIContext.enableCreatePassword ?? true ? CreatePasswordPage : AccountDetailsPage);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [validationSuccess]);

--- a/login-workflow/src/subScreens/AccountDetails.tsx
+++ b/login-workflow/src/subScreens/AccountDetails.tsx
@@ -80,11 +80,11 @@ export const emptyAccountDetailInformation = {
  * @param onSubmit callback called when user submits on the last form field to advance the screen
  * @param theme (Optional) react-native-paper theme partial for custom styling.
  */
-export type AccountDetailsProps = {
+export type AccountDetailsProps = React.PropsWithChildren<{
     onDetailsChanged(details: AccountDetailInformation | null): void;
     onSubmit?: () => void;
     theme?: ReactNativePaper.Theme;
-};
+}>;
 
 /**
  * Renders the content of the Account Details screen entry

--- a/login-workflow/yarn.lock
+++ b/login-workflow/yarn.lock
@@ -1101,10 +1101,10 @@
   resolved "https://registry.yarnpkg.com/@brightlayer-ui/prettier-config/-/prettier-config-1.0.3.tgz#e40a7ae7435c6fd5118acbf249080e0aa81e93af"
   integrity sha512-EYm3+V7Qd+oYEF+8FadsXAZqXryEHHbGnrV1BMp9selhABjceqUqXPVE4Sn3SKWQdBNJ3En2A3EzgrzRbvRTaw==
 
-"@brightlayer-ui/react-auth-shared@^3.7.3":
-  version "3.7.3"
-  resolved "https://registry.yarnpkg.com/@brightlayer-ui/react-auth-shared/-/react-auth-shared-3.7.3.tgz#546099802ab487cdc953a14c49d9b0dae0ad26a0"
-  integrity sha512-YghjDDg1TS4hy1mMlbbZ6dDsaplurTtv7Wl6F3bj8FTJeq5XRSE5huz/S2eMnd42gnHz4FFOVkI5sUo2MempRw==
+"@brightlayer-ui/react-auth-shared@^4.0.0-alpha.0":
+  version "4.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@brightlayer-ui/react-auth-shared/-/react-auth-shared-4.0.0-alpha.0.tgz#a11d55bb5f83bf87bebfd525acc2667e2029e4b4"
+  integrity sha512-TZJxxhb5i3cDdZbaPXL+qwLzedbgs/U5IlymR9ELc1dDuN8GMLePQnEI7o9LLu0AjzUYtm3fq19U/oM3HEqCwQ==
 
 "@brightlayer-ui/react-native-components@^7.0.0":
   version "7.0.0"


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Mimmic the hotfix from the React workflow package
- Allow hiding of the create password screen


#### To Test:

- yarn start:example

You will probably need to disable hermes in the Podfile of the example in order to run (I did)
<img width="1065" alt="image" src="https://user-images.githubusercontent.com/29152776/235231665-c0f5d26d-3012-4a8f-bb4f-ff777a90feb0.png">

And disable the password screen in App.tsx to see the effect
<img width="525" alt="image" src="https://user-images.githubusercontent.com/29152776/235231806-4e0c5022-8877-4ea6-a12d-2a41beaab994.png">

