### PR TITLE
Disable next button when valid is false in custom screen of registration flow

### DIFF
--- a/login-workflow/src/screens/SelfRegistrationPager.tsx
+++ b/login-workflow/src/screens/SelfRegistrationPager.tsx
@@ -342,7 +342,7 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
                     )}
                 </AccountDetailsScreen>
             ),
-            canGoForward: accountDetails !== null, // &&
+            canGoForward: accountDetails !== null && customAccountDetails ? customAccountDetails?.[0]?.valid : false,
             // accountDetails.valid,
             canGoBack: true,
         },


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes BLUI 4726 .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

-  Fix mentioned issue [276](https://github.com/etn-ccis/blui-react-native-workflows/issues/276)
-
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

- uncomment the below lines from `App.tsx`
`import { CustomAccountDetails, CustomAccountDetailsTwo } from './src/screens/CustomRegistrationForm';`

`customAccountDetails={[
                { component: CustomAccountDetails },
                {
                    title: 'Job Info',
                    instructions: 'Enter your employment information below.',
                    component: CustomAccountDetailsTwo,
                },
            ]}
  `

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- Test registration workflow. In this scenario, the Country should not be empty. If it is empty then the Next button will be disabled.

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
