### PR TITLE
Bug/4724 280 fix verify code screen field error

### DIFF
--- a/login-workflow/src/screens/SelfRegistrationPager.tsx
+++ b/login-workflow/src/screens/SelfRegistrationPager.tsx
@@ -150,6 +150,7 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
     const [accountAlreadyExists, setAccountAlreadyExists] = useState<boolean>(false);
     const [hasAcknowledgedError, setHasAcknowledgedError] = useState(false);
     const [currentPage, setCurrentPage] = useState(0);
+    const [resetInputField, setResetInputField] = useState(false);
 
     const viewPager = React.createRef<ViewPager>();
 
@@ -287,10 +288,9 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
             pageBody: (
                 <VerifyEmailScreen
                     key={'VerifyEmailPage'}
-                    initialCode={verificationCode}
+                    initialCode={!resetInputField ? '' : verificationCode}
                     onVerifyCodeChanged={setVerificationCode}
                     onResendVerificationEmail={(): void => {
-                        setVerificationCode('');
                         void requestCode();
                     }}
                     /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
@@ -474,8 +474,6 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
             }
         } catch {
             // do nothing
-        } finally {
-            setVerificationCode('');
         }
     }, [setHasAcknowledgedError, registrationActions, verificationCode, email, setAccountAlreadyExists]);
 
@@ -591,6 +589,7 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
                     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
                     (delta as number) > 0
                 ) {
+                    setResetInputField(false);
                     void requestCode();
                 } else if (
                     currentPage === VerifyEmailPage &&
@@ -599,11 +598,13 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
                     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
                     (delta as number) > 0
                 ) {
+                    setResetInputField(true);
                     void validateCode();
                 } else {
+                    if (currentPage === VerifyEmailPage && delta < 0) setResetInputField(true);
+                    if (currentPage === CreatePasswordPage && delta < 0) setResetInputField(false);
                     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
                     setCurrentPage(currentPage + (delta as number));
-                    setVerificationCode('');
                 }
             }
         },

--- a/login-workflow/src/screens/SelfRegistrationPager.tsx
+++ b/login-workflow/src/screens/SelfRegistrationPager.tsx
@@ -150,7 +150,6 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
     const [accountAlreadyExists, setAccountAlreadyExists] = useState<boolean>(false);
     const [hasAcknowledgedError, setHasAcknowledgedError] = useState(false);
     const [currentPage, setCurrentPage] = useState(0);
-    const [resetInputField, setResetInputField] = useState(false);
 
     const viewPager = React.createRef<ViewPager>();
 
@@ -288,7 +287,7 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
             pageBody: (
                 <VerifyEmailScreen
                     key={'VerifyEmailPage'}
-                    initialCode={!resetInputField ? '' : verificationCode}
+                    initialCode={verificationCode}
                     onVerifyCodeChanged={setVerificationCode}
                     onResendVerificationEmail={(): void => {
                         void requestCode();
@@ -441,6 +440,12 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
     const CreatePasswordPage = RegistrationPages.findIndex((item) => item.name === 'CreatePassword');
     const AccountDetailsPage = RegistrationPages.findIndex((item) => item.name === 'AccountDetails');
 
+    useEffect(() => {
+        if (currentPage === VerifyEmailPage) {
+            setVerificationCode('');
+        }
+    }, [currentPage, VerifyEmailPage]);
+
     // If there is a code and it is not confirmed, go to the verify screen
     useEffect((): void => {
         if (verificationCode && !codeRequestSuccess) {
@@ -589,7 +594,6 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
                     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
                     (delta as number) > 0
                 ) {
-                    setResetInputField(false);
                     void requestCode();
                 } else if (
                     currentPage === VerifyEmailPage &&
@@ -598,11 +602,8 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
                     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
                     (delta as number) > 0
                 ) {
-                    setResetInputField(true);
                     void validateCode();
                 } else {
-                    if (currentPage === VerifyEmailPage && delta < 0) setResetInputField(true);
-                    if (currentPage === CreatePasswordPage && delta < 0) setResetInputField(false);
                     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
                     setCurrentPage(currentPage + (delta as number));
                 }

--- a/login-workflow/src/subScreens/VerifyEmail.tsx
+++ b/login-workflow/src/subScreens/VerifyEmail.tsx
@@ -124,7 +124,12 @@ export const VerifyEmail: React.FC<VerifyEmailProps> = (props) => {
                     />
                     <View style={{ flex: 1, flexDirection: 'row', marginTop: 24, alignItems: 'center' }}>
                         <Body1>{t('blui:SELF_REGISTRATION.VERIFY_EMAIL.VERIFICATION_CODE_PROMPT')}</Body1>
-                        <TouchableOpacity onPress={(): void => onResendVerificationEmail()}>
+                        <TouchableOpacity
+                            onPress={(): void => {
+                                setVerifyCode('');
+                                onResendVerificationEmail();
+                            }}
+                        >
                             <Body1 color="primary">&nbsp;{t('blui:ACTIONS.RESEND')}</Body1>
                         </TouchableOpacity>
                     </View>


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes #280 BLUI-4724

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Fixed verify code screen input field issue
- Reset input field on next, back and resend button

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

- 

https://github.com/etn-ccis/blui-react-native-workflows/assets/120575281/a3101172-4907-41d5-9678-85a5ba26dcfd



<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- cd login-workflow
- yarn start:example
- Click on Register Now button
- Go through the flow till Verify Email screen
- Enter any valid value in the input field
- Click on Resend, Back or Next to see the field value is reset


<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
