### PR TITLE
Feature/5219 implement error manager component

### DIFF
--- a/login-workflow/docs/components/error-manager.md
+++ b/login-workflow/docs/components/error-manager.md
@@ -1,0 +1,46 @@
+# ErrorManager
+
+Component that manages the display of error messages. Can be configured to display a dialog, a message box, or neither. This component must be used within an `AuthContextProvider` or a `RegistrationContextProvider` for default values to work.
+
+## Usage
+```tsx
+import { ErrorManager } from '@brightlayer-ui/react-native-auth-workflow';
+
+...
+
+<ErrorManager>
+    {/* When configured as a message-box, the box will appear before or after the elements passed as children */}
+    {children} 
+</ErrorManager>
+```
+
+## API
+
+| Prop Name | Type | Description | Default |
+|---|---|---|---|
+| error | `string` | Error text to display. If string is empty, the error will not be shown. |  |
+| title | `string` | Title text to display for error dialog and message box. If string is empty, the title will not be shown. | |
+| mode | `'dialog' \| 'message-box' \| 'none'` | Determines whether to display a dialog, a message box, or neither. | `'dialog'` |
+| onClose | `() => void` | Function to call when the close/dismiss button is clicked. |  |
+| dialogConfig | `DialogConfigProps` | Configuration options for the dialog. See [DialogConfig Props](#dialogconfigprops) |  |
+| messageBoxConfig | `MessageBoxProps` | Configuration options for the message box. See [MessageBoxProps](#messageboxprops) |  |
+| children | `ReactNode` | Message box errors will appear before or after content passed as children. |  |
+
+### DialogConfigProps
+
+| Prop Name | Type | Description | Default |
+|---|---|---|---|
+| title | `string` | Text to show in the title of the dialog. | `t('bluiCommon:MESSAGES.ERROR')` |
+| dismissLabel | `string` | Label to show in the close button. | `t('bluiCommon:ACTIONS.CLOSE')` |
+| style | `StyleProp<ViewStyle>` | Style overrides object |  |
+
+### MessageBoxProps
+
+| Prop Name | Type | Description | Default |
+|---|---|---|---|
+| title | `string` | Text to show in the title of the dialog. | `t('bluiCommon:MESSAGES.ERROR')` |
+| dismissible | `boolean` | Whether the message box can be dismissed. | `true` |
+| position | `'top' \| 'bottom'` | Determines whether the message box should be displayed before or after children elements. | `'top'` |
+| fontColor | `string` | The font color of the text inside the message box. | `'error.contrastText'` |
+| backgroundColor | `string` | The background color of the message box. | `'error.main` |
+| style | `StyleProp<ViewStyle>` | Style overrides object |  |

--- a/login-workflow/docs/error-management.md
+++ b/login-workflow/docs/error-management.md
@@ -1,0 +1,84 @@
+# Error Management
+
+There are points throughout the workflow where a user may encounter errors, particularly when making calls to your back-end / API. There are a number of ways that you can control / configure how errors are presented throughout the UI.
+
+## TextField Validator Errors
+
+Text fields within the workflow have built in validator methods that you can customize. For more information on each screens validator functions, read our [Screens](./screens/README.md) documentation.
+
+Text field validator props accept a function. We pass the current value of the field as an argument and you should return a boolean value (true if there is no error) or string (for a custom message). When a text field has a validator error (i.e., the input is not valid), the error message that you returned in the validator function will be displayed below the input (if you return false, the text field will be rendered in an error state but no message will be displayed).
+
+### Example
+
+As an example, if you wanted to change what is accepted as a valid username on the Login screen (default is any valid email address), you can do so as follows:
+
+```tsx
+
+// accept ONLY @eaton.com email addresses
+const EMAIL_REGEX = /^[A-Z0-9._%+'-]+@eaton\.com$/i;
+...
+
+<LoginScreen
+    {...otherProps}
+    usernameValidator={{
+        (username: string): string | boolean => (
+            !EMAIL_REGEX.test(username) ? 'You must use your Eaton email address' : true
+        )
+    )}
+/>
+```
+
+## API Errors
+
+For API-related errors, we have implemented a common `ErrorManager` component that manages the display of error messages across screens. It can be customized to present API errors in a Dialog (default) or in a Message Box. For full details, read the [ErrorManager](./components/error-manager.md) API docs.
+
+To trigger the ErrorManager to display an error, you need to throw an error in your AuthUIAction or RegistrationUIAction function. 
+
+```tsx
+// throw a basic error
+throw new Error('My Custom Error');
+
+// customize the title via the cause property
+throw new Error('My Custom Error', {
+    cause: {
+        title: 'Custom Title',
+        errorMessage: 'My custom error message',
+    },
+});
+```
+
+### Global Configuration
+
+You can customize how errors are displayed throughout the entire workflow by passing an `errorConfig` prop to the `AuthContextProvider` and / or `RegistrationContextProvider`. This will change the default used by all of the screens nested under the provider.
+
+```tsx
+<AuthContextProvider
+    {...otherProps}
+    errorConfig={{
+        mode: 'message-box',
+        messageBoxConfig: {
+            dismissible: true,
+            position: 'top',
+        },
+    }}
+>
+```
+
+### Local Configuration
+
+You can configure how errors are rendered on each individual screen by adding an `errorConfig` prop directly on a screen component (e.g., if you want to show errors differently on the login screen vs. in the registration workflow).
+
+```tsx
+<LoginScreen
+    {...otherProps}
+    errorDisplayConfig={{
+        mode: 'message-box',
+        messageBoxConfig: {
+            dismissible: true,
+            position: 'top',
+        },
+    }}
+>
+```
+
+

--- a/login-workflow/example/src/navigation/index.tsx
+++ b/login-workflow/example/src/navigation/index.tsx
@@ -5,7 +5,7 @@ import { View } from 'react-native';
 import { NavigationDrawer } from './navigation-drawer';
 import { createStackNavigator } from '@react-navigation/stack';
 import Home from '../screens/home';
-import WorkFlowCardExample from '../screens/WorkFlowCardExample';
+import { WorkflowCardWrapper } from '../screens/WorkflowCardWrapper';
 
 const Drawer = createDrawerNavigator();
 
@@ -33,7 +33,7 @@ export const MainRouter = (): any => (
             drawerContent={(props: any): ReactNode => <CustomDrawerContent {...props} />}
         >
             <RootStack.Screen name="Home" component={Home} />
-            <RootStack.Screen name="WorkFlowCardExample" component={WorkFlowCardExample} />
+            <RootStack.Screen name="WorkFlowCardExample" component={WorkflowCardWrapper} />
         </Drawer.Navigator>
     </NavigationContainer>
 );

--- a/login-workflow/example/src/screens/WorkFlowCardExample.tsx
+++ b/login-workflow/example/src/screens/WorkFlowCardExample.tsx
@@ -1,28 +1,45 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { SafeAreaView, ScrollView } from 'react-native';
 import { Header } from '@brightlayer-ui/react-native-components';
-import { StackNavigationProp } from '@react-navigation/stack';
-import { RootStackParamList } from '../navigation';
 import {
     WorkflowCardBody,
     WorkflowCardInstructions,
     WorkflowCardActions,
+    ErrorManager,
+    useErrorManager,
 } from '@brightlayer-ui/react-native-auth-workflow';
-import { HelperText, TextInput } from 'react-native-paper';
+import { Button, HelperText, TextInput } from 'react-native-paper';
 import { useThemeContext } from '../context/ThemeContext';
 import { useExtendedTheme } from '@brightlayer-ui/react-native-themes';
 import { UserMenuExample } from '../components/UserMenuExample';
 import { toggleRTL } from './home';
+import { useNavigation } from '@react-navigation/native';
 
-type AppProps = {
-    navigation: StackNavigationProp<RootStackParamList, 'WorkFlowCardExample'>;
+const logIn = (): Promise<void> => {
+    throw new Error('My Custom Error');
 };
 
-const WorkFlowCardExample: React.FC<AppProps> = ({ navigation }): JSX.Element => {
+const WorkFlowCardExample: React.FC = () => {
     const theme = useExtendedTheme();
     const { theme: themeType, setTheme } = useThemeContext();
     const [errorFilledText, setErrorFilledText] = React.useState('Hello');
     const [hasError, setHasError] = React.useState(true);
+    const { triggerError, errorManagerConfig } = useErrorManager();
+    const navigation = useNavigation();
+    const errorDisplayConfig = {
+        ...errorManagerConfig,
+        onClose: (): void => {
+            if (errorManagerConfig.onClose) errorManagerConfig?.onClose();
+        },
+    };
+
+    const onNext = useCallback(async (): Promise<void> => {
+        try {
+            await logIn();
+        } catch (_error) {
+            triggerError(_error as Error);
+        }
+    }, [triggerError]);
 
     return (
         <>
@@ -49,22 +66,25 @@ const WorkFlowCardExample: React.FC<AppProps> = ({ navigation }): JSX.Element =>
                 <ScrollView>
                     <WorkflowCardInstructions instructions={'Test Instructions'} />
                     <WorkflowCardBody>
-                        <TextInput
-                            label="TextInput"
-                            mode="flat"
-                            left={<TextInput.Icon icon="email" />}
-                            right={<TextInput.Icon icon="menu-down" />}
-                            value={errorFilledText}
-                            underlineColor={theme.colors.surface}
-                            onChangeText={(value: string): void => {
-                                setErrorFilledText(value);
-                                setHasError(value.length > 4);
-                            }}
-                            error={hasError}
-                        />
-                        <HelperText type="error" visible={hasError} style={{ marginBottom: 8 }}>
-                            Error Message
-                        </HelperText>
+                        <ErrorManager {...errorDisplayConfig}>
+                            <TextInput
+                                label="TextInput"
+                                mode="flat"
+                                left={<TextInput.Icon icon="email" />}
+                                right={<TextInput.Icon icon="menu-down" />}
+                                value={errorFilledText}
+                                underlineColor={theme.colors.surface}
+                                onChangeText={(value: string): void => {
+                                    setErrorFilledText(value);
+                                    setHasError(value.length > 4);
+                                }}
+                                error={hasError}
+                            />
+                            <HelperText type="error" visible={hasError} style={{ marginBottom: 8 }}>
+                                Error Message
+                            </HelperText>
+                            <Button onPress={(): void => void onNext()}>Click for error</Button>
+                        </ErrorManager>
                     </WorkflowCardBody>
                 </ScrollView>
                 <WorkflowCardActions showPrevious showNext previousLabel="Back" nextLabel="Next" />

--- a/login-workflow/example/src/screens/WorkflowCardWrapper.tsx
+++ b/login-workflow/example/src/screens/WorkflowCardWrapper.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import WorkFlowCardExample from './WorkFlowCardExample';
+import { ErrorContextProvider } from '@brightlayer-ui/react-native-auth-workflow';
+
+export const WorkflowCardWrapper: React.FC = () => (
+    <ErrorContextProvider>
+        <WorkFlowCardExample />
+    </ErrorContextProvider>
+);

--- a/login-workflow/src/__tests__/components/Error/ErrorManager-test.tsx
+++ b/login-workflow/src/__tests__/components/Error/ErrorManager-test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { cleanup, render, RenderResult, screen } from '@testing-library/react-native';
+import { ErrorManager, ErrorManagerProps } from 'src/components';
+import { Provider as PaperProvider } from 'react-native-paper';
+import '@testing-library/react-native/extend-expect';
+
+describe('ErrorManager Test', () => {
+    const onClose = jest.fn();
+
+    const defaultProps: ErrorManagerProps = {
+        mode: 'dialog',
+        title: 'Error Manager',
+        error: 'Error Manager Message',
+        onClose,
+    };
+
+    const renderer = (props = defaultProps): RenderResult =>
+        render(
+            <PaperProvider>
+                <ErrorManager {...props} />
+            </PaperProvider>
+        );
+
+    afterEach(cleanup);
+
+    it('renders correctly', () => {
+        renderer();
+        expect(render).toBeTruthy();
+    });
+
+    it('should display title and error passed using props', () => {
+        renderer();
+        expect(screen.getByText('Error Manager')).toBeOnTheScreen();
+        expect(screen.getByText('Error Manager Message')).toBeOnTheScreen();
+    });
+
+    it('should display error dialog as default mode', () => {
+        renderer();
+        expect(screen.getByTestId('basic-dialog')).toBeOnTheScreen();
+    });
+    it('should display error dialog as default mode', () => {
+        const props = defaultProps;
+        props.mode = 'message-box';
+        renderer(props);
+        expect(screen.getByTestId('error-message-box-close')).toBeOnTheScreen();
+    });
+});

--- a/login-workflow/src/components/Error/ErrorManager.tsx
+++ b/login-workflow/src/components/Error/ErrorManager.tsx
@@ -1,0 +1,131 @@
+import React, { useCallback } from 'react';
+import { StyleProp, ViewStyle } from 'react-native';
+import { BasicDialog } from '../Dialog/BasicDialog';
+import { ErrorMessageBox } from './ErrorMessageBox';
+import { useTranslation } from 'react-i18next';
+
+export type AuthError = { cause: { title: string; errorMessage: string } };
+
+export type ErrorManagerProps = {
+    /**
+     * Determines whether to display a dialog, a message box, or neither
+     */
+    mode?: 'dialog' | 'message-box' | 'none';
+
+    /**
+     * Title to display in message box and dialog
+     */
+    title?: string;
+
+    /**
+     * The function to call when the close/dismiss button is clicked
+     * @returns void
+     */
+    onClose?: () => void;
+
+    /**
+     * The error text to display
+     */
+    error?: string;
+
+    /**
+     * Configuration options when using mode='dialog'
+     * @param {string} dialogConfig.title - The title used in the dialog header
+     * @param {string} dialogConfig.dismissLabel - The label on the dismiss button.
+     */
+    dialogConfig?: {
+        dismissLabel?: string;
+        title?: string;
+        style?: StyleProp<ViewStyle>;
+    };
+    messageBoxConfig?: {
+        title?: string;
+        dismissible?: boolean;
+        position?: 'top' | 'bottom';
+        fontColor?: string;
+        backgroundColor?: string;
+        style?: StyleProp<ViewStyle>;
+    };
+    children?: React.ReactNode;
+};
+
+/**
+ * Component that manages the display of error messages. Can be configured to display a dialog, a message box, or neither.
+ *
+ * @param mode determines whether to display a dialog, a message box, or neither
+ * @param onClose function to call when the close/dismiss button is clicked
+ * @param error error text to display
+ * @param dialogConfig configuration for the error dialog
+ * @param dialogConfig.title text to show in the title of the dialog
+ * @param dialogConfig.dismissLabel text to show in the close button
+ * @param dialogConfig.style style styles passed to the underlying root(Dialog) component
+ * @param messageBoxConfig configuration for the error message box
+ * @param messageBoxConfig.dismissible whether the message box can be dismissed
+ * @param messageBoxConfig.position determines whether the message box should be displayed at the top or bottom of the screen
+ * @param messageBoxConfig.fontColor the font color of the text inside the message box
+ * @param messageBoxConfig.backgroundColor the background color of the message box
+ * @param messageBoxConfig.style style styles passed to the underlying root(Box) component
+ *
+ * @category Component
+ */
+
+export const ErrorManager: React.FC<React.PropsWithChildren<ErrorManagerProps>> = (props) => {
+    const { t } = useTranslation();
+    const {
+        children,
+        mode = 'dialog',
+        title,
+        error = '',
+        onClose = (): void => {},
+        dialogConfig,
+        messageBoxConfig = {
+            position: 'top',
+        },
+    } = props;
+
+    const ErrorDialogWithProps = useCallback(
+        (): JSX.Element => (
+            <BasicDialog
+                testID="basic-dialog"
+                open={error.length > 0}
+                title={dialogConfig?.title ?? title ?? t('bluiCommon:MESSAGES.ERROR')}
+                body={t(error)}
+                onDismiss={onClose}
+                dismissButtonText={dialogConfig?.dismissLabel}
+                style={dialogConfig?.style}
+            />
+        ),
+        [dialogConfig, title, error, onClose, t]
+    );
+
+    const ErrorMessageBoxWithProps = useCallback((): JSX.Element => {
+        const { dismissible = true, fontColor, backgroundColor, style } = messageBoxConfig;
+
+        return (
+            <ErrorMessageBox
+                title={messageBoxConfig?.title ?? title ?? t('bluiCommon:MESSAGES.ERROR')}
+                errorMessage={t(error)}
+                dismissible={dismissible}
+                style={style}
+                backgroundColor={backgroundColor}
+                fontColor={fontColor}
+                onClose={onClose}
+            />
+        );
+    }, [error, title, t, messageBoxConfig, onClose]);
+
+    return mode === 'dialog' && error.length > 0 ? (
+        <>
+            {children}
+            <ErrorDialogWithProps />
+        </>
+    ) : mode === 'message-box' && error.length > 0 ? (
+        <>
+            {messageBoxConfig.position !== 'bottom' && <ErrorMessageBoxWithProps />}
+            {children}
+            {messageBoxConfig.position === 'bottom' && <ErrorMessageBoxWithProps />}
+        </>
+    ) : (
+        <>{children}</>
+    );
+};

--- a/login-workflow/src/components/Error/index.tsx
+++ b/login-workflow/src/components/Error/index.tsx
@@ -1,1 +1,2 @@
 export * from './ErrorMessageBox';
+export * from './ErrorManager';

--- a/login-workflow/src/contexts/ErrorContext/context.ts
+++ b/login-workflow/src/contexts/ErrorContext/context.ts
@@ -1,0 +1,8 @@
+/**
+ * @packageDocumentation
+ * @module ErrorContext
+ */
+import { createContext } from 'react';
+import { ErrorContextProviderProps } from './types';
+
+export const ErrorContext = createContext<ErrorContextProviderProps | null>(null);

--- a/login-workflow/src/contexts/ErrorContext/index.ts
+++ b/login-workflow/src/contexts/ErrorContext/index.ts
@@ -1,0 +1,23 @@
+import { useContext } from 'react';
+import { ErrorContext } from './context';
+import { ErrorContextProvider } from './provider';
+import { ErrorContextProviderProps } from './types';
+
+/**
+ * Hook to get top level error data
+ *
+ * @category Hooks
+ * @private
+ * @internal
+ */
+export const useErrorContext = (): ErrorContextProviderProps => {
+    const context = useContext(ErrorContext);
+    if (context === null) {
+        throw new Error('useErrorContext must be used within ErrorContextProvider');
+    }
+    return context;
+};
+
+export type { ErrorContextProviderProps };
+
+export { ErrorContext, ErrorContextProvider };

--- a/login-workflow/src/contexts/ErrorContext/index.ts
+++ b/login-workflow/src/contexts/ErrorContext/index.ts
@@ -2,7 +2,7 @@ import { useContext } from 'react';
 import { ErrorContext } from './context';
 import { ErrorContextProvider } from './provider';
 import { ErrorContextProviderProps } from './types';
-
+import { useErrorManager } from './useErrorManager';
 /**
  * Hook to get top level error data
  *
@@ -20,4 +20,4 @@ export const useErrorContext = (): ErrorContextProviderProps => {
 
 export type { ErrorContextProviderProps };
 
-export { ErrorContext, ErrorContextProvider };
+export { ErrorContext, ErrorContextProvider, useErrorManager };

--- a/login-workflow/src/contexts/ErrorContext/provider.tsx
+++ b/login-workflow/src/contexts/ErrorContext/provider.tsx
@@ -1,0 +1,14 @@
+/**
+ * @packageDocumentation
+ * @module ErrorContextProvider
+ */
+
+import React from 'react';
+import { ErrorContextProviderProps } from './types';
+import { ErrorContext } from './context';
+
+export const ErrorContextProvider: React.FC<React.PropsWithChildren<ErrorContextProviderProps>> = (props) => {
+    const { children, ...ErrorContextProps } = props;
+
+    return <ErrorContext.Provider value={ErrorContextProps}>{children}</ErrorContext.Provider>;
+};

--- a/login-workflow/src/contexts/ErrorContext/types.ts
+++ b/login-workflow/src/contexts/ErrorContext/types.ts
@@ -1,0 +1,8 @@
+/**
+ * @packageDocumentation
+ * @module ErrorContext
+ */
+
+import { ErrorManagerProps } from '../../components/Error/ErrorManager';
+
+export type ErrorContextProviderProps = Omit<ErrorManagerProps, 'error'>;

--- a/login-workflow/src/contexts/ErrorContext/useErrorManager.tsx
+++ b/login-workflow/src/contexts/ErrorContext/useErrorManager.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+import { AuthError, ErrorManagerProps } from '../../components/Error';
+import { useErrorContext } from '.';
+
+export const useErrorManager = (): {
+    triggerError: (error: Error | AuthError) => void;
+    errorManagerConfig: ErrorManagerProps;
+} => {
+    const errorConfig = useErrorContext();
+    const [error, setError] = useState<Error | AuthError>(new Error());
+
+    const isAuthError = (err: Error | AuthError): err is AuthError => (err as AuthError).cause !== undefined;
+
+    const getErrorDisplayConfig = (err: Error | AuthError): ErrorManagerProps => {
+        if (isAuthError(err)) {
+            return {
+                ...errorConfig,
+                dialogConfig: { title: err.cause.title },
+                error: err.cause.errorMessage,
+                onClose: (): void => {
+                    setError(new Error());
+                },
+            };
+        }
+        return {
+            ...errorConfig,
+            error: err.message,
+            onClose: (): void => {
+                setError(new Error());
+            },
+        };
+    };
+
+    const triggerError = (err: Error | AuthError): void => {
+        if (isAuthError(err)) {
+            setError({
+                cause: {
+                    title: err.cause.title,
+                    errorMessage: err.cause.errorMessage,
+                },
+            });
+        } else {
+            setError(err);
+        }
+    };
+
+    return { triggerError: triggerError, errorManagerConfig: getErrorDisplayConfig(error) };
+};

--- a/login-workflow/src/contexts/index.tsx
+++ b/login-workflow/src/contexts/index.tsx
@@ -1,0 +1,1 @@
+export * from './ErrorContext';

--- a/login-workflow/src/index.ts
+++ b/login-workflow/src/index.ts
@@ -1,1 +1,2 @@
 export * from './components';
+export * from './contexts';


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes # BLUI-5213

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Added ErrorManager component, tests and docs
- Added Error context, provider and useContext hook
- Added useManager hook
- Updatedexample

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

- 
![Simulator Screenshot - iphone 12 pro - 2024-02-05 at 19 40 51](https://github.com/etn-ccis/blui-react-native-workflows/assets/120575281/c0d39d28-9450-4528-a3a4-58428ac4545e)


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- cd login-workflows
- yarn start:example
- Click on Workflow Card Example
- Click on `Click for error`

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

- **Note: Translation for title will work when https://github.com/etn-ccis/blui-react-native-workflows/pull/331 gets merged**
