### PR TITLE
Update header styles

### DIFF
--- a/login-workflow/src/components/WorkflowCard/WorkflowCardHeader.tsx
+++ b/login-workflow/src/components/WorkflowCard/WorkflowCardHeader.tsx
@@ -44,26 +44,38 @@ export type WorkflowCardHeaderProps = Omit<ViewProps, 'children'> & {
 };
 
 const makeStyles = (
-    theme: ExtendedTheme
+    theme: ExtendedTheme,
+    isTablet: boolean,
+    backgroundColor?: string,
+    textColor?: string
 ): StyleSheet.NamedStyles<{
-    Header: ViewStyle;
-    title: ViewStyle;
+    header: ViewStyle;
+    mobileHeader: ViewStyle;
+    tabletHeader: ViewStyle;
     headerContent: ViewStyle;
+    headerText: ViewStyle;
 }> =>
     StyleSheet.create({
-        Header: {
+        header: {
             height: 64,
             paddingHorizontal: 16,
             paddingVertical: 12,
             alignItems: 'center',
             flexDirection: 'row',
         },
-        title: {
-            fontFamily: theme.fonts.labelLarge.fontFamily,
+        mobileHeader: {
+            backgroundColor: backgroundColor || theme.colors.primaryContainer,
+        },
+        tabletHeader: {
+            backgroundColor: backgroundColor || 'transparent',
         },
         headerContent: {
             marginLeft: 30,
             justifyContent: 'center',
+            color: textColor || isTablet ? theme.colors.onSurface : theme.colors.onPrimaryContainer,
+        },
+        headerText: {
+            color: textColor || isTablet ? theme.colors.onSurface : theme.colors.onPrimaryContainer,
         },
     });
 /**
@@ -81,8 +93,8 @@ const makeStyles = (
 export const WorkflowCardHeader: React.FC<WorkflowCardHeaderProps> = (props) => {
     const { title, subTitle, backgroundColor, textColor, iconColor, icon, style, onIconPress, ...otherprops } = props;
     const theme = useExtendedTheme();
-    const defaultStyles = makeStyles(theme);
     const { isTablet } = useScreenDimensions();
+    const defaultStyles = makeStyles(theme, isTablet, backgroundColor, textColor);
     const insets = useSafeAreaInsets();
     const statusBarHeight = insets.top;
     const getIcon = (): JSX.Element | undefined => {
@@ -111,8 +123,8 @@ export const WorkflowCardHeader: React.FC<WorkflowCardHeaderProps> = (props) => 
             )}
             <View
                 style={[
-                    { backgroundColor: backgroundColor || theme.colors.primaryContainer },
-                    defaultStyles.Header,
+                    isTablet ? defaultStyles.tabletHeader : defaultStyles.mobileHeader,
+                    defaultStyles.header,
                     style,
                 ]}
                 {...otherprops}
@@ -121,14 +133,11 @@ export const WorkflowCardHeader: React.FC<WorkflowCardHeaderProps> = (props) => 
                     {getIcon()}
                 </TouchableOpacity>
                 <View style={defaultStyles.headerContent}>
-                    <Text
-                        variant="titleLarge"
-                        style={[{ color: textColor || theme.colors.onPrimaryContainer }, defaultStyles.title]}
-                    >
+                    <Text variant="titleLarge" style={[defaultStyles.headerText]}>
                         {title}
                     </Text>
                     {subTitle && (
-                        <Text variant="bodyMedium" style={[{ color: textColor || theme.colors.onPrimaryContainer }]}>
+                        <Text variant="bodyMedium" style={[defaultStyles.headerText]}>
                             {subTitle}
                         </Text>
                     )}

--- a/login-workflow/src/components/WorkflowCard/WorkflowCardHeader.tsx
+++ b/login-workflow/src/components/WorkflowCard/WorkflowCardHeader.tsx
@@ -52,7 +52,7 @@ const makeStyles = (
 }> =>
     StyleSheet.create({
         Header: {
-            height: 60,
+            height: 64,
             paddingHorizontal: 16,
             paddingVertical: 12,
             alignItems: 'center',
@@ -87,23 +87,34 @@ export const WorkflowCardHeader: React.FC<WorkflowCardHeaderProps> = (props) => 
     const statusBarHeight = insets.top;
     const getIcon = (): JSX.Element | undefined => {
         if (icon) {
-            return <Icon source={icon} color={iconColor || theme.colors.onPrimary} size={18} />;
+            return <Icon source={icon} color={iconColor || theme.colors.onSurface} size={18} />;
         }
-        return <Icon source={{ name: 'close' }} color={iconColor || theme.colors.onPrimary} size={24} />;
+        return <Icon source={{ name: 'close' }} color={iconColor || theme.colors.onSurface} size={24} />;
     };
     return (
         <View>
             {!isTablet && (
-                <View style={{ backgroundColor: backgroundColor || theme.colors.primary, height: statusBarHeight }}>
+                <View
+                    style={{
+                        backgroundColor: backgroundColor || theme.colors.primaryContainer,
+                        height: statusBarHeight,
+                    }}
+                >
                     <StatusBar
                         barStyle={
-                            Color(backgroundColor || theme.colors.primary).isDark() ? 'light-content' : 'dark-content'
+                            Color(backgroundColor || theme.colors.primaryContainer).isDark()
+                                ? 'light-content'
+                                : 'dark-content'
                         }
                     />
                 </View>
             )}
             <View
-                style={[{ backgroundColor: backgroundColor || theme.colors.primary }, defaultStyles.Header, style]}
+                style={[
+                    { backgroundColor: backgroundColor || theme.colors.primaryContainer },
+                    defaultStyles.Header,
+                    style,
+                ]}
                 {...otherprops}
             >
                 <TouchableOpacity testID="workflow-card-icon" onPress={onIconPress}>
@@ -112,12 +123,12 @@ export const WorkflowCardHeader: React.FC<WorkflowCardHeaderProps> = (props) => 
                 <View style={defaultStyles.headerContent}>
                     <Text
                         variant="titleLarge"
-                        style={[{ color: textColor || theme.colors.onPrimary }, defaultStyles.title]}
+                        style={[{ color: textColor || theme.colors.onPrimaryContainer }, defaultStyles.title]}
                     >
                         {title}
                     </Text>
                     {subTitle && (
-                        <Text variant="bodyLarge" style={[{ color: textColor || theme.colors.onPrimary }]}>
+                        <Text variant="bodyMedium" style={[{ color: textColor || theme.colors.onPrimaryContainer }]}>
                             {subTitle}
                         </Text>
                     )}


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes 5340 .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- height should be updated to 64px

- Default background color should be the lighter blue color (refer to what we used in Header)

- On tablet (when in a card), theCardHeader background should match the background of the card and the text should be the darker default text color.

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)
<img width="597" alt="Screenshot 2024-02-13 at 4 05 42 PM" src="https://github.com/etn-ccis/blui-react-native-workflows/assets/133877691/dc0dd3be-21d0-4a3e-ab8e-663f88201c96">


<img width="948" alt="Screenshot 2024-02-13 at 5 16 02 PM" src="https://github.com/etn-ccis/blui-react-native-workflows/assets/133877691/38075006-5dce-4394-8c73-6d1ecb37c375">

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:
 - GO to workflow card example and check font, color, background color of  title, and subtitle as per [Figma](https://www.figma.com/file/Nydz8n8HBj6U3ZtULja3gD/%F0%9F%92%AB-Brightlayer-UI-Tokens-%2B-Components-(in-Material-Design-3)?type=design&node-id=417-3219&mode=design&t=XRIUIGYColAsbP4g-0) 


<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
