### PR TITLE
Updated success screen translations with bold tag

### DIFF
--- a/login-workflow/src/contexts/RegistrationContext/RegistrationDictionaries/chinese.ts
+++ b/login-workflow/src/contexts/RegistrationContext/RegistrationDictionaries/chinese.ts
@@ -20,13 +20,13 @@ const resources: RegistrationLanguageFile = {
                 PASSWORD_INFO: '请输入您的新密码。请确保您的新密码符合以下列出的密码复杂度要求。',
             },
             SUCCESS_MESSAGE:
-                '您已成功使用<b>{{email}}</b>注册了一个新账号。\n\n您的账号已被加入“<b>{{organization}}</b>”。',
+                '您已成功使用<boldTag>{{email}}</boldTag>注册了一个新账号。\n\n您的账号已被加入“<boldTag>{{organization}}</boldTag>”。',
             SUCCESS_MESSAGE_ALT:
-                '您已成功使用<1>{{email}}</1>注册了一个新账号。\n\n您的账号已被加入“<3>{{organization}}</3>”。',
+                '您已成功使用<boldTag>{{email}}</boldTag>注册了一个新账号。\n\n您的账号已被加入“<boldTag>{{organization}}</boldTag>”。',
             SUCCESS_MESSAGE_WITHOUT_EMAIL_PROVIDED:
-                '您已成功注册了一个新账号。\n\n您的账号已被加入“<b>{{organization}}</b>”。',
+                '您已成功注册了一个新账号。\n\n您的账号已被加入“<boldTag>{{organization}}</boldTag>”。',
             SUCCESS_MESSAGE_ALT_WITHOUT_EMAIL_PROVIDED:
-                '您已成功注册了一个新账号。\n\n您的账号已被加入“<3>{{organization}}</3>”。',
+                '您已成功注册了一个新账号。\n\n您的账号已被加入“<boldTag>{{organization}}</boldTag>”。',
             SUCCESS_EXISTING: '您已成功建立账号。请使用您的伊顿账号邮箱和密码登录。',
             FAILURE_MESSAGE: '无法完成注册。',
             UNKNOWN_EMAIL: '未知邮箱地址',

--- a/login-workflow/src/contexts/RegistrationContext/RegistrationDictionaries/french.ts
+++ b/login-workflow/src/contexts/RegistrationContext/RegistrationDictionaries/french.ts
@@ -20,13 +20,13 @@ const resources: RegistrationLanguageFile = {
                 PASSWORD_INFO: `Veuillez sélectionner un mot de passe. Assurez-vous que votre mot de passe répond aux exigences de complexité nécessaires décrites ci-dessous.`,
             },
             SUCCESS_MESSAGE:
-                "Votre compte a été créé avec le courrier électronique <b>{{email}}</b>.\n\nVotre compte a déjà été ajouté à l'organisation <b>{{organization}}</b>.",
+                "Votre compte a été créé avec le courrier électronique <boldTag>{{email}}</boldTag>.\n\nVotre compte a déjà été ajouté à l'organisation <boldTag>{{organization}}</boldTag>.",
             SUCCESS_MESSAGE_ALT:
-                "Votre compte a été créé avec le courrier électronique <1>{{email}}</1>.\n\nVotre compte a déjà été ajouté à l'organisation <3>{{organization}}</3>.",
+                "Votre compte a été créé avec le courrier électronique <boldTag>{{email}}</boldTag>.\n\nVotre compte a déjà été ajouté à l'organisation <boldTag>{{organization}}</boldTag>.",
             SUCCESS_MESSAGE_WITHOUT_EMAIL_PROVIDED:
-                "Votre compte à été créé avec succès.\n\nVotre compte a déjà été ajouté à l'organisation <b>{{organization}}</b>.",
+                "Votre compte à été créé avec succès.\n\nVotre compte a déjà été ajouté à l'organisation <boldTag>{{organization}}</boldTag>.",
             SUCCESS_MESSAGE_ALT_WITHOUT_EMAIL_PROVIDED:
-                "Votre compte à été créé avec succès.\n\nVotre compte a déjà été ajouté à l'organisation <3>{{organization}}</3>.",
+                "Votre compte à été créé avec succès.\n\nVotre compte a déjà été ajouté à l'organisation <boldTag>{{organization}}</boldTag>.",
             SUCCESS_EXISTING: `Votre compte à été créé avec succès. Veuillez vous connecter avec l'adresse e-mail et le mot de passe de votre compte Eaton.`,
             FAILURE_MESSAGE:
                 "Nous n'avons pas pu terminer votre inscription. Appuyez sur Continuer ci-dessous pour finir.",

--- a/login-workflow/src/contexts/RegistrationContext/RegistrationDictionaries/portuguese.ts
+++ b/login-workflow/src/contexts/RegistrationContext/RegistrationDictionaries/portuguese.ts
@@ -21,13 +21,13 @@ const resources: RegistrationLanguageFile = {
                     'Por favor selecione uma palavra-passe. Certifique-se de que sua senha atenda aos requisitos de complexidade necessários descritos abaixo.',
             },
             SUCCESS_MESSAGE:
-                'A sua conta foi criada corretamente com o e-mail <b>{{email}}</b>.\n\nA sua conta já foi adicionada à organização <b>{{organization}}</b>.',
+                'A sua conta foi criada corretamente com o e-mail <boldTag>{{email}}</boldTag>.\n\nA sua conta já foi adicionada à organização <boldTag>{{organization}}</boldTag>.',
             SUCCESS_MESSAGE_ALT:
-                'A sua conta foi criada corretamente com o e-mail <1>{{email}}</1>.\n\nA sua conta já foi adicionada à organização <3>{{organization}}</3>.',
+                'A sua conta foi criada corretamente com o e-mail <boldTag>{{email}}</boldTag>.\n\nA sua conta já foi adicionada à organização <boldTag>{{organization}}</boldTag>.',
             SUCCESS_MESSAGE_WITHOUT_EMAIL_PROVIDED:
-                'A Sua conta foi criada com sucesso.\n\nA sua conta já foi adicionada à organização <b>{{organization}}</b>.',
+                'A Sua conta foi criada com sucesso.\n\nA sua conta já foi adicionada à organização <boldTag>{{organization}}</boldTag>.',
             SUCCESS_MESSAGE_ALT_WITHOUT_EMAIL_PROVIDED:
-                'A Sua conta foi criada com sucesso.\n\nA sua conta já foi adicionada à organização <3>{{organization}}</3>.',
+                'A Sua conta foi criada com sucesso.\n\nA sua conta já foi adicionada à organização <boldTag>{{organization}}</boldTag>.',
             SUCCESS_EXISTING:
                 'A sua conta foi criada corretamente. Por favor inicie sessão com o e-mail e palavra-passe da sua conta Eaton.',
             FAILURE_MESSAGE: 'Foi impossível concluir o seu registo.',

--- a/login-workflow/src/contexts/RegistrationContext/RegistrationDictionaries/spanish.ts
+++ b/login-workflow/src/contexts/RegistrationContext/RegistrationDictionaries/spanish.ts
@@ -21,13 +21,13 @@ const resources: RegistrationLanguageFile = {
                     'Por favor, seleccione una contraseña. Asegúrese de que su contraseña cumple con los requisitos de complejidad necesarios que se describen a continuación. ',
             },
             SUCCESS_MESSAGE:
-                'Su cuenta se ha creado correctamente con el correo electrónico <b>{{email}}</b>.\n\nTu cuenta ya se ha agregado a la organización <b>{{organization}}</b>.',
+                'Su cuenta se ha creado correctamente con el correo electrónico <boldTag>{{email}}</boldTag>.\n\nTu cuenta ya se ha agregado a la organización <boldTag>{{organization}}</boldTag>.',
             SUCCESS_MESSAGE_ALT:
-                'Su cuenta se ha creado correctamente con el correo electrónico <1>{{email}}</1>.\n\nTu cuenta ya se ha agregado a la organización <3>{{organization}}</3>.',
+                'Su cuenta se ha creado correctamente con el correo electrónico <boldTag>{{email}}</boldTag>.\n\nTu cuenta ya se ha agregado a la organización <boldTag>{{organization}}</boldTag>.',
             SUCCESS_MESSAGE_WITHOUT_EMAIL_PROVIDED:
-                'Su cuenta ha sido creada satisfactoriamente.\n\nTu cuenta ya se ha agregado a la organización <b>{{organization}}</b>.',
+                'Su cuenta ha sido creada satisfactoriamente.\n\nTu cuenta ya se ha agregado a la organización <boldTag>{{organization}}</boldTag>.',
             SUCCESS_MESSAGE_ALT_WITHOUT_EMAIL_PROVIDED:
-                'Su cuenta ha sido creada satisfactoriamente.\n\nTu cuenta ya se ha agregado a la organización <3>{{organization}}</3>.',
+                'Su cuenta ha sido creada satisfactoriamente.\n\nTu cuenta ya se ha agregado a la organización <boldTag>{{organization}}</boldTag>.',
             SUCCESS_EXISTING:
                 'Tu cuenta ha sido creada con éxito. Inicie sesión con el correo electrónico y la contraseña de su cuenta Eaton. ',
             FAILURE_MESSAGE: 'No pudimos completar su registro. ',


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes # BLUI-5498
We miss this in https://github.com/etn-ccis/blui-react-native-workflows/pull/387

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Updated other language success screen translations with bold tag

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

- 
![Simulator Screenshot - iPhone 12 - 2024-03-15 at 18 30 29](https://github.com/etn-ccis/blui-react-native-workflows/assets/120575281/6bfb15b2-f4e2-4897-81d4-6c120ae3ee9f)


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- cd login-workflows
- yarn start:example
- Change the language to other than English
- Open drawer
- Press Registration Provider Example
- Go through registration process to see the success screen
- Email and organisation name should be bold

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
