### PR TITLE
Bug/5535 174 text field visibilty toggle keyboard

### DIFF
--- a/login-workflow/CHANGELOG.md
+++ b/login-workflow/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## v6.0.0 (Unreleased)
 
 ### Fixed
 
+-   Keyboard persists issue on visibility icon toggle [174](https://github.com/etn-ccis/blui-react-native-workflows/issues/174).
 -   Using keyboard done button [265](https://github.com/etn-ccis/blui-react-native-workflows/issues/265).
 -   Navigation and error handling updated [275](https://github.com/etn-ccis/blui-react-native-workflows/issues/275).
 -   Disable next button for invalid inputs [276](https://github.com/etn-ccis/blui-react-native-workflows/issues/276).

--- a/login-workflow/src/components/WorkflowCard/WorkflowCardBody.tsx
+++ b/login-workflow/src/components/WorkflowCard/WorkflowCardBody.tsx
@@ -37,7 +37,11 @@ export const WorkflowCardBody: React.FC<WorkflowCardBodyProps> = (props) => {
     return (
         <>
             {scrollable ? (
-                <ScrollView contentInsetAdjustmentBehavior="automatic" bounces={false}>
+                <ScrollView
+                    contentInsetAdjustmentBehavior="automatic"
+                    bounces={false}
+                    keyboardShouldPersistTaps={'handled'}
+                >
                     <Card.Content style={[defaultStyles.workflowBody, style]} {...otherCardContentProps}>
                         {children}
                     </Card.Content>


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes # BLUI-5535 #174 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Added `keyboardShouldPersistTaps={'handled'}` to ScrollView 

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

- 

https://github.com/etn-ccis/blui-react-native-workflows/assets/120575281/05d7269d-37c4-4fc0-a425-c978453cfe7a



<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- cd login-workflow
- yarn start:example
- Open drawer
- Press Registration Provider Example
- Go through registration process till Create Password Screen
- Open virtual keyboard (Ctrl + K)
- Enter few characters in field and toggle visiblity icon
- Enter remaining password
- The virtual keyboard is visible

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
