### PR TITLE
Clicking on the next button in the registration workflow shows the previous screen and drawer for a fraction of a second

### DIFF
--- a/login-workflow/example/ios/example.xcodeproj/project.pbxproj
+++ b/login-workflow/example/ios/example.xcodeproj/project.pbxproj
@@ -618,7 +618,8 @@
 				);
 				OTHER_LDFLAGS = (
 					"$(inherited)",
-					" ",
+					"-Wl",
+					"-ld_classic",
 				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
@@ -689,7 +690,8 @@
 				);
 				OTHER_LDFLAGS = (
 					"$(inherited)",
-					" ",
+					"-Wl",
+					"-ld_classic",
 				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;

--- a/login-workflow/example/src/screens/RegistrationProviderExample.tsx
+++ b/login-workflow/example/src/screens/RegistrationProviderExample.tsx
@@ -54,10 +54,10 @@ const RegistrationProviderExample: React.FC<AppProps> = (): JSX.Element => {
 
             {/* implementation with custom screens. This custom screen is using app and workflow level translations  */}
             <RegistrationWorkflow>
-                <EulaScreen />
+                {/* <EulaScreen />
                 <CustomScreen />
                 <CreatePasswordScreen />
-                <VerifyCodeScreen />
+                <VerifyCodeScreen /> */}
             </RegistrationWorkflow>
 
             {/* Show default success screen */}

--- a/login-workflow/example/src/screens/RegistrationProviderExample.tsx
+++ b/login-workflow/example/src/screens/RegistrationProviderExample.tsx
@@ -6,11 +6,11 @@ import i18nAppInstance from '../../translations/i18n';
 import {
     RegistrationContextProvider,
     RegistrationWorkflow,
-    EulaScreen,
+    // EulaScreen,
     // ErrorContextProvider,
     // AccountDetailsScreen,
-    CreatePasswordScreen,
-    VerifyCodeScreen,
+    // CreatePasswordScreen,
+    // VerifyCodeScreen,
     // WorkflowCard,
     // WorkflowCardHeader,
     // WorkflowCardBody,
@@ -18,7 +18,7 @@ import {
 } from '@brightlayer-ui/react-native-auth-workflow';
 import { RootStackParamList } from '../navigation';
 import { useNavigation } from '@react-navigation/native';
-import { CustomScreen } from '../components/CustomScreen';
+// import { CustomScreen } from '../components/CustomScreen';
 
 type AppProps = {
     navigation: StackNavigationProp<RootStackParamList, 'RegistrationProviderExample'>;

--- a/login-workflow/src/components/RegistrationWorkflow/RegistrationWorkflow.tsx
+++ b/login-workflow/src/components/RegistrationWorkflow/RegistrationWorkflow.tsx
@@ -20,6 +20,7 @@ import {
 } from '../../screens';
 import { ErrorManagerProps } from '../Error';
 import { Spinner } from '../Spinner';
+import { timeOutDelay } from '../../constants';
 
 const styles = StyleSheet.create({
     pagerView: {
@@ -160,7 +161,7 @@ export const RegistrationWorkflow: React.FC<React.PropsWithChildren<Registration
         try {
             setTimeout(() => {
                 setLoading(true);
-            }, 100);
+            }, timeOutDelay);
             if (actions && actions.completeRegistration) {
                 const { Eula, CreateAccount, VerifyCode, CreatePassword, AccountDetails, Other } = screenData;
                 const userInfo = {
@@ -190,7 +191,7 @@ export const RegistrationWorkflow: React.FC<React.PropsWithChildren<Registration
         } finally {
             setTimeout(() => {
                 setLoading(false);
-            }, 100);
+            }, timeOutDelay);
         }
     };
 

--- a/login-workflow/src/components/RegistrationWorkflow/RegistrationWorkflow.tsx
+++ b/login-workflow/src/components/RegistrationWorkflow/RegistrationWorkflow.tsx
@@ -19,6 +19,7 @@ import {
     ExistingAccountSuccessScreen,
 } from '../../screens';
 import { ErrorManagerProps } from '../Error';
+import { Spinner } from '../Spinner';
 
 const styles = StyleSheet.create({
     pagerView: {
@@ -153,8 +154,13 @@ export const RegistrationWorkflow: React.FC<React.PropsWithChildren<Registration
         viewPagerRef.current?.setPage(0);
     };
 
+    const [loading, setLoading] = useState(false);
+
     const finishRegistration = async (data: IndividualScreenData): Promise<void> => {
         try {
+            setTimeout(() => {
+                setLoading(true);
+            }, 100);
             if (actions && actions.completeRegistration) {
                 const { Eula, CreateAccount, VerifyCode, CreatePassword, AccountDetails, Other } = screenData;
                 const userInfo = {
@@ -181,6 +187,10 @@ export const RegistrationWorkflow: React.FC<React.PropsWithChildren<Registration
             }
         } catch (err) {
             console.error(err);
+        } finally {
+            setTimeout(() => {
+                setLoading(false);
+            }, 100);
         }
     };
 
@@ -257,6 +267,7 @@ export const RegistrationWorkflow: React.FC<React.PropsWithChildren<Registration
                         ))}
                     </PagerView>
                 )}
+                {loading ? <Spinner visible={loading} /> : null}
             </ErrorManager>
         </RegistrationWorkflowContextProvider>
     );

--- a/login-workflow/src/constants/index.ts
+++ b/login-workflow/src/constants/index.ts
@@ -2,6 +2,7 @@ import { PasswordRequirement } from 'src/components';
 
 export const EMAIL_REGEX = /^[A-Z0-9._%+'-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i;
 export const USERNAME_REGEX = /^[^\r\n\t\f\v ]+$/;
+export const timeOutDelay = 100;
 
 /////////////////////////////////////////////////////////////////////////////////////
 // NOTE: The following Regular expressions are used for the

--- a/login-workflow/src/screens/AccountDetailsScreen/AccountDetailsScreen.tsx
+++ b/login-workflow/src/screens/AccountDetailsScreen/AccountDetailsScreen.tsx
@@ -5,6 +5,7 @@ import { useRegistrationWorkflowContext } from '../../contexts/RegistrationWorkf
 import { useErrorManager } from '../../contexts/ErrorContext';
 import { AccountDetailsScreenBase } from './AccountDetailsScreenBase';
 import { useRegistrationContext } from '../../contexts/RegistrationContext';
+import { timeOutDelay } from '../../constants';
 
 /**
  * Component renders a screen with account details information for support with the application.
@@ -14,7 +15,6 @@ import { useRegistrationContext } from '../../contexts/RegistrationContext';
  *
  * @category Component
  */
-
 export const AccountDetailsScreen: React.FC<AccountDetailsScreenProps> = (props) => {
     const { t } = useTranslation();
     const { actions, navigate } = useRegistrationContext();
@@ -46,7 +46,7 @@ export const AccountDetailsScreen: React.FC<AccountDetailsScreenProps> = (props)
         } finally {
             setTimeout(() => {
                 setIsLoading(false);
-            }, 100);
+            }, timeOutDelay);
         }
     }, [actions, firstName, lastName, nextScreen, triggerError]);
 

--- a/login-workflow/src/screens/AccountDetailsScreen/AccountDetailsScreen.tsx
+++ b/login-workflow/src/screens/AccountDetailsScreen/AccountDetailsScreen.tsx
@@ -44,7 +44,9 @@ export const AccountDetailsScreen: React.FC<AccountDetailsScreenProps> = (props)
         } catch (_error) {
             triggerError(_error as Error);
         } finally {
-            setIsLoading(false);
+            setTimeout(() => {
+                setIsLoading(false);
+            }, 100);
         }
     }, [actions, firstName, lastName, nextScreen, triggerError]);
 

--- a/login-workflow/src/screens/ContactScreen/ContactSupportScreen.tsx
+++ b/login-workflow/src/screens/ContactScreen/ContactSupportScreen.tsx
@@ -25,7 +25,6 @@ const makeStyles = (
  *
  * @category Component
  */
-
 export const ContactSupportScreen: React.FC<ContactSupportScreenProps> = (props) => {
     const { t } = useTranslation();
     const { navigate } = useAuthContext();

--- a/login-workflow/src/screens/CreateAccountScreen/CreateAccountScreen.tsx
+++ b/login-workflow/src/screens/CreateAccountScreen/CreateAccountScreen.tsx
@@ -43,7 +43,9 @@ export const CreateAccountScreen: React.FC<CreateAccountScreenProps> = (props) =
         } catch (_error) {
             triggerError(_error as Error);
         } finally {
-            setIsLoading(false);
+            setTimeout(() => {
+                setIsLoading(false);
+            }, 100);
         }
     }, [actions, emailInputValue, nextScreen, triggerError]);
 

--- a/login-workflow/src/screens/CreateAccountScreen/CreateAccountScreen.tsx
+++ b/login-workflow/src/screens/CreateAccountScreen/CreateAccountScreen.tsx
@@ -4,7 +4,7 @@ import { CreateAccountScreenBase } from './CreateAccountScreenBase';
 import { useRegistrationWorkflowContext, useRegistrationContext } from '../../contexts';
 import { useErrorManager } from '../../contexts/ErrorContext/useErrorManager';
 import { useTranslation } from 'react-i18next';
-import { EMAIL_REGEX } from '../../constants';
+import { EMAIL_REGEX, timeOutDelay } from '../../constants';
 
 /**
  * Component that renders a screen for the user to enter their email address to start the
@@ -14,7 +14,6 @@ import { EMAIL_REGEX } from '../../constants';
  *
  * @category Component
  */
-
 export const CreateAccountScreen: React.FC<CreateAccountScreenProps> = (props) => {
     const { t } = useTranslation();
     const { actions, navigate } = useRegistrationContext();
@@ -45,7 +44,7 @@ export const CreateAccountScreen: React.FC<CreateAccountScreenProps> = (props) =
         } finally {
             setTimeout(() => {
                 setIsLoading(false);
-            }, 100);
+            }, timeOutDelay);
         }
     }, [actions, emailInputValue, nextScreen, triggerError]);
 

--- a/login-workflow/src/screens/CreateAccountScreen/CreateAccountScreenBase.tsx
+++ b/login-workflow/src/screens/CreateAccountScreen/CreateAccountScreenBase.tsx
@@ -71,6 +71,7 @@ export const CreateAccountScreenBase: React.FC<CreateAccountScreenProps & { inpu
                         label={emailLabel}
                         value={emailInput}
                         error={shouldValidateEmail && !isEmailValid}
+                        autoCapitalize="none"
                         {...emailTextFieldProps}
                         onChangeText={(text): void => {
                             // eslint-disable-next-line no-unused-expressions

--- a/login-workflow/src/screens/CreatePasswordScreen/CreatePasswordScreen.tsx
+++ b/login-workflow/src/screens/CreatePasswordScreen/CreatePasswordScreen.tsx
@@ -68,7 +68,9 @@ export const CreatePasswordScreen: React.FC<CreatePasswordScreenProps> = (props)
         } catch (_error) {
             triggerError(_error as Error);
         } finally {
-            setIsLoading(false);
+            setTimeout(() => {
+                setIsLoading(false);
+            }, 100);
         }
     }, [actions, passwordInput, nextScreen, confirmInput, triggerError]);
 

--- a/login-workflow/src/screens/CreatePasswordScreen/CreatePasswordScreen.tsx
+++ b/login-workflow/src/screens/CreatePasswordScreen/CreatePasswordScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useRef, useState } from 'react';
 import { CreatePasswordScreenBase } from './CreatePasswordScreenBase';
-import { defaultPasswordRequirements } from '../../constants';
+import { defaultPasswordRequirements, timeOutDelay } from '../../constants';
 import { CreatePasswordScreenProps } from './types';
 import { useRegistrationContext, useRegistrationWorkflowContext } from '../../contexts';
 import { useErrorManager } from '../../contexts/ErrorContext/useErrorManager';
@@ -13,7 +13,6 @@ import { useTranslation } from 'react-i18next';
  *
  * @category Component
  */
-
 export const CreatePasswordScreen: React.FC<CreatePasswordScreenProps> = (props) => {
     const { t } = useTranslation();
     const { actions, navigate } = useRegistrationContext();
@@ -70,7 +69,7 @@ export const CreatePasswordScreen: React.FC<CreatePasswordScreenProps> = (props)
         } finally {
             setTimeout(() => {
                 setIsLoading(false);
-            }, 100);
+            }, timeOutDelay);
         }
     }, [actions, passwordInput, nextScreen, confirmInput, triggerError]);
 

--- a/login-workflow/src/screens/EulaScreen/EulaScreen.tsx
+++ b/login-workflow/src/screens/EulaScreen/EulaScreen.tsx
@@ -121,7 +121,9 @@ export const EulaScreen: React.FC<EulaScreenProps> = (props) => {
         } catch (_error) {
             triggerError(_error as Error);
         } finally {
-            setIsLoading(false);
+            setTimeout(() => {
+                setIsLoading(false);
+            }, 100);
         }
     }, [actions, nextScreen, triggerError, isInviteRegistration, screenData, t, updateScreenData]);
 

--- a/login-workflow/src/screens/EulaScreen/EulaScreen.tsx
+++ b/login-workflow/src/screens/EulaScreen/EulaScreen.tsx
@@ -4,6 +4,7 @@ import { EulaScreenBase } from './EulaScreenBase';
 import { useRegistrationContext, useRegistrationWorkflowContext } from '../../contexts';
 import { useErrorManager } from '../../contexts/ErrorContext/useErrorManager';
 import { useTranslation } from 'react-i18next';
+import { timeOutDelay } from '../../constants';
 
 /**
  * Component that renders a screen displaying the EULA and requests acceptance via a checkbox.
@@ -12,7 +13,6 @@ import { useTranslation } from 'react-i18next';
  *
  * @category Component
  */
-
 export const EulaScreen: React.FC<EulaScreenProps> = (props) => {
     const { t } = useTranslation();
     const { actions, language, navigate } = useRegistrationContext();
@@ -123,7 +123,7 @@ export const EulaScreen: React.FC<EulaScreenProps> = (props) => {
         } finally {
             setTimeout(() => {
                 setIsLoading(false);
-            }, 100);
+            }, timeOutDelay);
         }
     }, [actions, nextScreen, triggerError, isInviteRegistration, screenData, t, updateScreenData]);
 

--- a/login-workflow/src/screens/ExistingAccountSuccessScreen/ExistingAccountSuccessScreen.tsx
+++ b/login-workflow/src/screens/ExistingAccountSuccessScreen/ExistingAccountSuccessScreen.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useRegistrationContext, useRegistrationWorkflowContext } from '../../contexts';
 import { SuccessScreenBase, SuccessScreenProps } from '../SuccessScreen';
 import { useTranslation } from 'react-i18next';
+
 /**
  * Full screen component that renders a Success Screen for the accounts that already exists in the records
  *
@@ -9,7 +10,6 @@ import { useTranslation } from 'react-i18next';
  *
  * @category Component
  */
-
 export const ExistingAccountSuccessScreen: React.FC<SuccessScreenProps> = (props) => {
     const { t } = useTranslation();
     const { navigate, routeConfig } = useRegistrationContext();

--- a/login-workflow/src/screens/RegistrationSuccessScreen/RegistrationSuccessScreen.tsx
+++ b/login-workflow/src/screens/RegistrationSuccessScreen/RegistrationSuccessScreen.tsx
@@ -21,7 +21,6 @@ const makeStyles = (): StyleSheet.NamedStyles<{
  *
  * @category Component
  */
-
 export const RegistrationSuccessScreen: React.FC<SuccessScreenProps> = (props) => {
     const { t } = useTranslation();
     const styles = makeStyles();

--- a/login-workflow/src/screens/VerifyCodeScreen/VerifyCodeScreen.tsx
+++ b/login-workflow/src/screens/VerifyCodeScreen/VerifyCodeScreen.tsx
@@ -87,7 +87,9 @@ export const VerifyCodeScreen: React.FC<VerifyCodeScreenProps> = (props) => {
             } catch (_error) {
                 triggerError(_error as Error);
             } finally {
-                setIsLoading(false);
+                setTimeout(() => {
+                    setIsLoading(false);
+                }, 100);
             }
         },
         [t, actions, nextScreen, triggerError, updateScreenData]

--- a/login-workflow/src/screens/VerifyCodeScreen/VerifyCodeScreen.tsx
+++ b/login-workflow/src/screens/VerifyCodeScreen/VerifyCodeScreen.tsx
@@ -3,6 +3,7 @@ import { VerifyCodeScreenProps } from './types';
 import { VerifyCodeScreenBase } from './VerifyCodeScreenBase';
 import { useTranslation } from 'react-i18next';
 import { useErrorManager, useRegistrationContext, useRegistrationWorkflowContext } from '../../contexts';
+import { timeOutDelay } from '../../constants';
 
 /**
  * Component that renders a screen that prompts a user to enter the confirmation code
@@ -89,7 +90,7 @@ export const VerifyCodeScreen: React.FC<VerifyCodeScreenProps> = (props) => {
             } finally {
                 setTimeout(() => {
                     setIsLoading(false);
-                }, 100);
+                }, timeOutDelay);
             }
         },
         [t, actions, nextScreen, triggerError, updateScreenData]

--- a/login-workflow/src/screens/VerifyCodeScreen/VerifyCodeScreenBase.tsx
+++ b/login-workflow/src/screens/VerifyCodeScreen/VerifyCodeScreenBase.tsx
@@ -87,6 +87,7 @@ export const VerifyCodeScreenBase: React.FC<React.PropsWithChildren<VerifyCodeSc
                         value={verifyCode}
                         onChangeText={handleVerifyCodeInputChange}
                         error={shouldValidateCode && !isCodeValid}
+                        autoCapitalize="none"
                         {...verifyCodeTextInputProps}
                         onSubmitEditing={(): void => {
                             if (verifyCode.length > 0 && isCodeValid && actionsProps.canGoNext) handleOnNext();


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes #BLUI-5524 .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Added setTimeout when `loading` is setting false.
-
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

-

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

-

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

- Please add your feedback on whether this code changes need to be merged or not, since these [code changes](https://github.com/etn-ccis/blui-react-native-workflows/pull/432/files) reduced showing the previous screen, but still we can see it.
