### PR TITLE
Cybersecurity image size configuration

### DIFF
--- a/login-workflow/CHANGELOG.md
+++ b/login-workflow/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v6.0.1-alpha.0
+
+### Fixed
+
+-   Make cybersecurity badge size configurable [497](https://github.com/etn-ccis/blui-react-native-workflows/issues/497).
+
 ## v6.0.1 (July 23, 2024)
 
 ### Fixed

--- a/login-workflow/docs/screens/login.md
+++ b/login-workflow/docs/screens/login.md
@@ -78,7 +78,7 @@ import { AuthContextProvider, LoginScreen } from '@brightlayer-ui/react-native-a
 | Prop Name | Type | Description | Default |
 |---|---|---|---|
 | showCyberSecurityBadge | `boolean` | Whether or not to show the cyber security badge. | `true` |
-| cyberSecurityBadgeSize | `object` | Prop for adding custom height and width to cyber security badge. |  |
+| cyberSecurityBadgeSize | `{height?: number \| string, width?: number \| string}` | Prop for adding custom height and width to cyber security badge. |  |
 | projectImage | `ReactNode` | Image to display at the top of the screen. |  |
 | header | `ReactNode` | Custom content to display at the top of the screen. |  |
 | footer | `ReactNode` | Custom content to display at the bottom of the screen. |  |

--- a/login-workflow/docs/screens/login.md
+++ b/login-workflow/docs/screens/login.md
@@ -78,6 +78,7 @@ import { AuthContextProvider, LoginScreen } from '@brightlayer-ui/react-native-a
 | Prop Name | Type | Description | Default |
 |---|---|---|---|
 | showCyberSecurityBadge | `boolean` | Whether or not to show the cyber security badge. | `true` |
+| cyberSecurityBadgeSize | `object` | Prop for adding custom height and width to cyber security badge. |  |
 | projectImage | `ReactNode` | Image to display at the top of the screen. |  |
 | header | `ReactNode` | Custom content to display at the top of the screen. |  |
 | footer | `ReactNode` | Custom content to display at the bottom of the screen. |  |

--- a/login-workflow/src/screens/LoginScreen/LoginScreen.tsx
+++ b/login-workflow/src/screens/LoginScreen/LoginScreen.tsx
@@ -74,6 +74,7 @@ export const LoginScreen: React.FC<React.PropsWithChildren<LoginScreenProps>> = 
         projectImage,
         header,
         footer,
+        cyberSecurityBadgeSize,
     } = props;
 
     return (
@@ -119,6 +120,7 @@ export const LoginScreen: React.FC<React.PropsWithChildren<LoginScreenProps>> = 
             projectImage={projectImage}
             header={header}
             footer={footer}
+            cyberSecurityBadgeSize={cyberSecurityBadgeSize}
         />
     );
 };

--- a/login-workflow/src/screens/LoginScreen/LoginScreenBase.tsx
+++ b/login-workflow/src/screens/LoginScreen/LoginScreenBase.tsx
@@ -104,7 +104,7 @@ const makeStyles = (
             marginBottom: isTablet ? 32 : 24,
         },
         footerWrapper: { display: 'flex', justifyContent: 'center' },
-        cyberSecurityBadgeWrapper: { display: 'flex', justifyContent: 'center', marginTop: 2 },
+        cyberSecurityBadgeWrapper: { display: 'flex', flexDirection: 'row', justifyContent: 'center', marginTop: 2 },
     });
 
 /**
@@ -144,6 +144,7 @@ export const LoginScreenBase: React.FC<React.PropsWithChildren<LoginScreenProps>
         projectImage,
         header,
         footer,
+        cyberSecurityBadgeSize,
         ...otherProps
     } = props;
 
@@ -380,7 +381,7 @@ export const LoginScreenBase: React.FC<React.PropsWithChildren<LoginScreenProps>
                         testID={'blui-login-cyber-security-badge-wrapper'}
                     >
                         <Image
-                            style={{ width: '100%' }}
+                            style={{...cyberSecurityBadgeSize}}
                             resizeMode="contain"
                             source={require('../../assets/images/cybersecurity_certified.png')}
                         />

--- a/login-workflow/src/screens/LoginScreen/types.ts
+++ b/login-workflow/src/screens/LoginScreen/types.ts
@@ -166,4 +166,9 @@ export type LoginScreenProps = WorkflowCardBaseProps & {
      * The footer to display at the bottom of the screen
      */
     footer?: JSX.Element;
+
+    /**
+     * The size of the cyber security image
+     */
+    cyberSecurityBadgeSize?: {height?: number | string, width?: number | string};
 };


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes # .
- Fixed cybersecurity image size configuration issue. 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Added prop for adding height and width to make cybersecurity image confiugurable
- Changes flex direction to align item to the center
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)
<img width="323" alt="Screenshot 2024-07-30 at 12 06 15 PM" src="https://github.com/user-attachments/assets/26563e9d-99ac-4230-9341-66b5c23dc2b7">


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- Run command start:example-android 
- Open file Login.tsx
- Add prop cyberSecurityBadgeSize={{height: 160, width: 150}} in LoginScreen component to add custom height & width

    `
 <LoginScreen

            projectImage={
                <Image
                    style={{ width: '100%' }}
                    resizeMode="contain"
                    source={require('../assets/images/eaton_stacked_logo.png')}
                />
            }
            header={<DebugComponent />}
            cyberSecurityBadgeSize={{height: 160, width: 150}}
        />
`

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
