### PR TITLE
Fixed login keyboard dismiss error on login click

### DIFF
--- a/login-workflow/CHANGELOG.md
+++ b/login-workflow/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v7.0.1 (November 11, 2024)
+
+### Fixed
+
+- Pressing login does not dismiss keyboard and can obscure error modal [514](https://github.com/etn-ccis/blui-react-native-workflows/issues/514)
+
 ## v7.0.0 (September 20, 2024)
 
 ### Fixed

--- a/login-workflow/package.json
+++ b/login-workflow/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@brightlayer-ui/react-native-auth-workflow",
     "description": "Re-usable workflow components for Authentication and Registration within Eaton applications.",
-    "version": "7.0.0",
+    "version": "7.0.1",
     "license": "BSD-3-Clause",
     "author": {
         "name": "Brightlayer UI",

--- a/login-workflow/package.json
+++ b/login-workflow/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@brightlayer-ui/react-native-auth-workflow",
     "description": "Re-usable workflow components for Authentication and Registration within Eaton applications.",
-    "version": "7.0.1",
+    "version": "7.0.1-alpha.0",
     "license": "BSD-3-Clause",
     "author": {
         "name": "Brightlayer UI",

--- a/login-workflow/src/screens/LoginScreen/LoginScreen.tsx
+++ b/login-workflow/src/screens/LoginScreen/LoginScreen.tsx
@@ -96,8 +96,8 @@ export const LoginScreen: React.FC<React.PropsWithChildren<LoginScreenProps>> = 
                 (async (username: string, password: string, rememberMe: boolean): Promise<void> => {
                     try {
                         setIsLoading(true);
-                        await actions.logIn(username, password, rememberMe);
                         await props.onLogin?.(username, password, rememberMe);
+                        await actions.logIn(username, password, rememberMe);
                     } catch (_error) {
                         triggerError(_error as Error);
                     } finally {

--- a/login-workflow/src/screens/LoginScreen/LoginScreen.tsx
+++ b/login-workflow/src/screens/LoginScreen/LoginScreen.tsx
@@ -96,8 +96,8 @@ export const LoginScreen: React.FC<React.PropsWithChildren<LoginScreenProps>> = 
                 (async (username: string, password: string, rememberMe: boolean): Promise<void> => {
                     try {
                         setIsLoading(true);
-                        await props.onLogin?.(username, password, rememberMe);
                         await actions.logIn(username, password, rememberMe);
+                        await props.onLogin?.(username, password, rememberMe);
                     } catch (_error) {
                         triggerError(_error as Error);
                     } finally {

--- a/login-workflow/src/screens/LoginScreen/LoginScreenBase.tsx
+++ b/login-workflow/src/screens/LoginScreen/LoginScreenBase.tsx
@@ -3,7 +3,7 @@ import { LoginScreenProps } from './types';
 import { WorkflowCard } from '../../components/WorkflowCard';
 import { WorkflowCardBody } from '../../components/WorkflowCard/WorkflowCardBody';
 import { ErrorManager, PasswordTextField } from '../../components';
-import { Image, View, StyleSheet, ViewStyle } from 'react-native';
+import { Image, View, StyleSheet, ViewStyle, Keyboard } from 'react-native';
 import { Button, Checkbox, HelperText, Text, TextInput } from 'react-native-paper';
 import { useExtendedTheme } from '@brightlayer-ui/react-native-themes';
 import { useScreenDimensions } from '../../hooks/useScreenDimensions';
@@ -200,6 +200,7 @@ export const LoginScreenBase: React.FC<React.PropsWithChildren<LoginScreenProps>
     };
 
     const handleRememberMeChanged = (value: boolean): void => {
+        Keyboard.dismiss();
         if (onRememberMeChanged) {
             onRememberMeChanged(value);
             setRememberMe(value);
@@ -213,6 +214,7 @@ export const LoginScreenBase: React.FC<React.PropsWithChildren<LoginScreenProps>
         isPasswordValid;
 
     const handleLogin = (): void => {
+        Keyboard.dismiss();
         if (isFormValid() && onLogin) void onLogin(username, password, rememberMe);
     };
     const handleLoginSubmit = (): void => {


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes https://github.com/etn-ccis/blui-react-native-workflows/issues/514.

- Fixed keyboard dismiss error on login screen

To test -->

- Run yarn start:example-android
- Open index.tsx under navigation folder and replace OktaLogin with Login

